### PR TITLE
Use gcc on FreeBSD 10

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+CC=gcc
 CFLAGS=-O2 -Wall -g
 LDFLAGS=-lX11 -lXi
 


### PR DESCRIPTION
FreeBSD 10 uses clang by default. This errors out with
xlossage.c:35:10: fatal error: 'X11/Xlib.h' file not found

I don't know enough about C programming/compiles to make it work with clang, so I opted to force make to use gcc instead, which works perfectly.
